### PR TITLE
Add feature to setup custom API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Options: <br>
 `-v, --version -> Gives the Version of the CLI` <br>
 `-s, --search -> Search a question on Stackoverflow` <br>
 `-d, --debug -> Turn on Debugging mode` <br>
+`-c, --custom -> Setup a custom API key` <br>
 `-h, --help -> Shows this message and exit` <br>
 
 ## License🗄

--- a/main.py
+++ b/main.py
@@ -34,6 +34,11 @@ parser.add_argument("-file",
                     help="Save answer to a file",
                     action="store_true")
 
+parser.add_argument("-c",
+                    "--custom",
+                    help="Set a custom API key",
+                    action="store_true")
+
 ARGV = parser.parse_args()
 
 search_flag = Search(ARGV)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ requests==2.24.0
 termcolor==1.1.0
 urllib3==1.25.10
 rich==9.9.0
+oauthlib==3.1.0
+requests-oauthlib==1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,8 @@ urllib3==1.25.10
 rich==9.9.0
 oauthlib==3.1.0
 requests-oauthlib==1.3.0
+colorama==0.4.4
+configparser==5.0.2
+crayons==0.4.0
+selenium==3.141.0
+webdriver-manager==3.3.0

--- a/src/arguments/search.py
+++ b/src/arguments/search.py
@@ -39,6 +39,8 @@ class Search():
                 webbrowser.open(f"{url}?title={self.arguments.new}")
             else:
                 webbrowser.open(url)
+        elif self.arguments.custom:
+            self.utility_object.setCustomKey()
 
     def search_for_results(self, save=False):
         queries = ["What do you want to search", "Tags"]

--- a/src/arguments/search.py
+++ b/src/arguments/search.py
@@ -40,14 +40,11 @@ class Search():
                 webbrowser.open(f"{url}?title={self.arguments.new}")
             else:
                 webbrowser.open(url)
-<<<<<<< HEAD
         elif self.arguments.custom:
             self.utility_object.setCustomKey()
-=======
         elif self.arguments.update:
             update = UpdateApplication(version)
             update.check_for_updates()
->>>>>>> 8953712129b15eb66ca2240c2e01e01e3bcfd7ee
 
     def search_for_results(self, save=False):
         queries = ["What do you want to search", "Tags"]

--- a/src/arguments/utility.py
+++ b/src/arguments/utility.py
@@ -140,7 +140,6 @@ class Utility():
 
         # Close the window after 20s (Assuming that the user logs in within 30 seconds)
         time.sleep(30)
-        
         # Close the windows as soon as authorization is done
         try:
             WebDriverWait(driver, 1).until(

--- a/src/arguments/utility.py
+++ b/src/arguments/utility.py
@@ -148,7 +148,7 @@ class Utility():
             callback_url = driver.current_url
         finally:
             driver.quit()
-        
+
         # Extract access token data from callback_url
         accessTokenData = stackApps.token_from_fragment(callback_url)
 

--- a/src/arguments/utility.py
+++ b/src/arguments/utility.py
@@ -9,7 +9,6 @@ from .markdown import MarkdownRenderer
 
 # Required for OAuth
 import json
-import webbrowser
 from oauthlib.oauth2 import MobileApplicationClient
 from requests_oauthlib import OAuth2Session
 
@@ -144,7 +143,7 @@ class Utility():
         
         # Close the windows as soon as authorization is done
         try:
-            element = WebDriverWait(driver, 1).until(
+            WebDriverWait(driver, 1).until(
                 EC.presence_of_element_located((By.TAG_NAME, "h2"))
             )
             callback_url = driver.current_url

--- a/src/arguments/utility.py
+++ b/src/arguments/utility.py
@@ -94,13 +94,14 @@ class Utility():
         return ans
 
     # Get an access token and extract to a JSON file "access_token.json"
+    @classmethod
     def setCustomKey(self):
         client_id = 20013
 
         # scopes possible values:
         # read_inbox - access a user's global inbox
         # no_expiry - access_token's with this scope do not expire
-        # write_access - perform write operations as a user 
+        # write_access - perform write operations as a user
         # private_info - access full history of a user's private actions on the site
         scopes = 'read_inbox'
 
@@ -121,7 +122,7 @@ class Utility():
         jsonDict = {
             "access_token": accessTokenData['access_token'],
             "expires": accessTokenData['expires'],
-            "state": accessTokenData['state']
+            "state": state
         }
 
         with open('access_token.json', 'w') as jsonFile:

--- a/src/arguments/utility.py
+++ b/src/arguments/utility.py
@@ -117,7 +117,7 @@ class Utility():
         callback_url = input("Paste URL after authenticating here: ")
         accessTokenData = stackApps.token_from_fragment(callback_url)
 
-        # Store the access token data in a JSON file
+        # Store the access token data in a dictionary
         jsonDict = {
             "access_token": accessTokenData['access_token'],
             "expires": accessTokenData['expires'],

--- a/src/arguments/utility.py
+++ b/src/arguments/utility.py
@@ -7,6 +7,12 @@ from .error import SearchError
 from .save import SaveSearchResults
 from .markdown import MarkdownRenderer
 
+# Required for OAuth
+import json
+import webbrowser
+from oauthlib.oauth2 import MobileApplicationClient
+from requests_oauthlib import OAuth2Session
+
 console = Console()
 
 
@@ -86,3 +92,37 @@ class Utility():
                     console.print(output_text)
             ans.append(json_ans_data["items"])
         return ans
+
+    # Get an access token and extract to a JSON file "access_token.json"
+    def setCustomKey(self):
+        client_id = 20013
+
+        # scopes possible values:
+        # read_inbox - access a user's global inbox
+        # no_expiry - access_token's with this scope do not expire
+        # write_access - perform write operations as a user 
+        # private_info - access full history of a user's private actions on the site
+        scopes = 'read_inbox'
+
+        authorization_url = 'https://stackoverflow.com/oauth/dialog'
+        redirect_uri = 'https://stackexchange.com/oauth/login_success'
+
+        # Create an OAuth session and open the auth_url in a browser for the user to authenticate
+        stackApps = OAuth2Session(client=MobileApplicationClient(client_id=client_id), scope=scopes, redirect_uri=redirect_uri)
+        auth_url, state = stackApps.authorization_url(authorization_url)
+        print(f"Visit this page in your browser: {auth_url}")
+        webbrowser.open(auth_url)
+
+        # Extract the access token data and save to a variable
+        callback_url = input("Paste URL after authenticating here: ")
+        accessTokenData = stackApps.token_from_fragment(callback_url)
+
+        # Store the access token data in a JSON file
+        jsonDict = {
+            "access_token": accessTokenData['access_token'],
+            "expires": accessTokenData['expires'],
+            "state": accessTokenData['state']
+        }
+
+        with open('access_token.json', 'w') as jsonFile:
+            json.dump(jsonDict, jsonFile)


### PR DESCRIPTION
## Related Issue
<!--
- Setup your own custom Stackoverflow api key.
-->

Closes: #48 

## Describe the changes you've made 
Added a function `setCustomKey()` in `utility.py` file for performing authentication and saving the access token data to `access_token.json`. Added code in `main.py` file to show a command-line argument(`-c / --custom`) for setting custom API key. Also, added an `elif` statement in `search.py` to make the `setCustomKey()` function call.

## Checklist:
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.

## Screenshots

### Web browser opens for authentication. If this does not work, the user can copy the url from the terminal and paste in the browser.

![1](https://user-images.githubusercontent.com/55907631/113738468-8d463880-971c-11eb-8650-3eec6ad825e8.jpeg)

### The user then pastes the URL after authentication back into the terminal.

![image](https://user-images.githubusercontent.com/55907631/113739307-4a389500-971d-11eb-8d58-7bda07908576.png)


### The access token data is stored in `access_token.json` file.

![image](https://user-images.githubusercontent.com/55907631/113738522-9afbbe00-971c-11eb-9135-c7f8802b74ee.png)

