### PR TITLE
Fix ValueError in Question-number user input: stackexchange

### DIFF
--- a/src/arguments/utility.py
+++ b/src/arguments/utility.py
@@ -164,7 +164,10 @@ class Utility():
             console.rule("[bold blue]", style="bold red", align="right")
             # Asks the user for next question number. Makes it the active question and the loop restarts
             while True:
-                posx = int(input("Enter the question number you want to view (Press 0 to quit): ")) - 1
+                try:
+                    posx = int(input("Enter the question number you want to view (Press 0 to quit): ")) - 1
+                except ValueError:
+                    SearchError("You didn't enter a question number", "Enter a question number from the relevant questions list")
                 if (posx == -1):
                     return
                 elif (0<=posx<len(questions_data)):


### PR DESCRIPTION
## Related Issue
- CLI had a runtime error whenever user input a string instead of number at question number input prompt

Closes: #33 


## Describe the changes you've made
Added an error handling code at user input prompt for dealing with string input instead of numerical. I am using the already implemented SearchError class.


## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.

## Screenshots

|        Original         |          Updated           |
| :---------------------: | :------------------------: |
| **![before](https://user-images.githubusercontent.com/26577306/115139868-0bc2a480-a052-11eb-8c03-c7eee225c8e8.png)** | <b> ![after](https://user-images.githubusercontent.com/26577306/115139877-1715d000-a052-11eb-8514-4b08e020ce6b.png)
 </b> |
