### PR TITLE
Create navigation enabled question panel

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ crayons==0.4.0
 selenium==3.141.0
 webdriver-manager==3.3.0
 simple-term-menu==1.0.1
-keyboard==0.13.5
+jupyterlab-pygments==0.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,5 @@ configparser==5.0.2
 crayons==0.4.0
 selenium==3.141.0
 webdriver-manager==3.3.0
+simple-term-menu==1.0.1
+keyboard==0.13.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,3 @@ crayons==0.4.0
 selenium==3.141.0
 webdriver-manager==3.3.0
 simple-term-menu==1.0.1
-jupyterlab-pygments==0.1.2

--- a/src/arguments/markdown.py
+++ b/src/arguments/markdown.py
@@ -33,6 +33,3 @@ class MarkdownRenderer(object):
 
     def __str__(self):
         return str(self.render)
-
-    def __repr__(self):
-        return str(self.render)

--- a/src/arguments/search.py
+++ b/src/arguments/search.py
@@ -54,7 +54,7 @@ class Search():
         queries = ["What do you want to search", "Tags"]
         query_solutions = []
 
-        # ask quesiton
+        # ask question
         for each_query in queries:
             # Be careful if there are
             # KeyBoard Interrupts or EOErrors

--- a/src/arguments/utility.py
+++ b/src/arguments/utility.py
@@ -79,12 +79,11 @@ class QuestionsPanel_stackoverflow():
             json_ans_data = resp.json()
             for item in json_ans_data["items"]:
                 if not(self.answer_data[item['question_id']]):
-                    self.answer_data[item['question_id']] = item['body_markdown'] 
-
+                    self.answer_data[item['question_id']] = item['body_markdown']
         # Sometimes the StackExchange API fails to deliver some answers. The below code is to fetch them
         failed_ques_id = [question[1] for question in self.questions_data if not(self.answer_data[question[1]])]
         if not(len(failed_ques_id) == 0):
-            self.populate_answer_data(failed_ques_id)                
+            self.populate_answer_data(failed_ques_id)
 
     def return_formatted_ans(self, ques_id):
         # This function uses pygments lexers ad formatters to format the content in the preview screen

--- a/src/arguments/utility.py
+++ b/src/arguments/utility.py
@@ -35,7 +35,7 @@ from webdriver_manager.microsoft import EdgeChromiumDriverManager
 
 console = Console()
 
-class QuestionsPanel_stackoverflow():
+class QuestionsPanelStackoverflow():
     def __init__(self):
         self.questions_data = []                        # list(  list( question_title, question_id, question_link )...  )
         self.answer_data = defaultdict(lambda: False)   # dict( question_id:list( body, link )) corresponding to self.questions_data
@@ -186,7 +186,7 @@ class Utility():
         This Function creates QuestionsPanel_stackoverflow class which supports
         Rendering, navigation, searching and redirecting capabilities
         """
-        stackoverflow_panel = QuestionsPanel_stackoverflow()
+        stackoverflow_panel = QuestionsPanelStackoverflow()
         stackoverflow_panel.display_panel(questions_list)
         # Support for reddit searching can also be implemented from here
 

--- a/src/arguments/utility.py
+++ b/src/arguments/utility.py
@@ -2,9 +2,16 @@ from termcolor import colored
 import requests
 from rich.console import Console
 import sys as sys
+
+# Required for Questions Panel
 import os
 import time
 from collections import defaultdict
+from simple_term_menu import TerminalMenu
+import webbrowser
+from pygments import highlight
+from pygments.lexers.markup import MarkdownLexer
+from pygments.formatters import Terminal256Formatter
 
 from .error import SearchError
 from .save import SaveSearchResults
@@ -28,6 +35,86 @@ from webdriver_manager.microsoft import EdgeChromiumDriverManager
 
 console = Console()
 
+class Questions_Panel_Stackoverflow():
+    def __init__(self):
+        self.questions_data = []                        # list(  list( question_title, question_link, question_id )...  )
+        self.answer_data = defaultdict(lambda: False)   # dict( question_id:list( body, link )) corresponding to self.questions_data
+        self.batch_ques_id = ""
+        self.line_color = "bold red"
+        self.heading_color = "bold blue"
+        self.search_content_url = "https://api.stackexchange.com/"
+
+    def populate_question_data(self, questions_list):
+        """ Function to populate question data property
+            Creates batch_id request to stackexchange API and
+            Stores the returned data data in the following format:
+                list(  list( question_title, question_link, question_id )  )
+        """
+        for question_id in questions_list:
+            self.batch_ques_id += str(question_id) + ";"
+        try:
+            resp = requests.get(
+                f"{self.search_content_url}/2.2/questions/{self.batch_ques_id[:-1]}?order=desc&sort=votes&site=stackoverflow&filter=!--1nZwsgqvRX"
+            )
+        except:
+            SearchError("Search Failed", "Try connecting to the internet")
+            sys.exit()
+        json_ques_data = resp.json()
+        self.questions_data = [[item['title'], item['question_id'], item['link']] for item in json_ques_data["items"]]
+        return
+
+    def populate_answer_data(self):
+        """ Function to populate answer data property
+            Creates batch_id request to stackexchange API and
+            Stores the returned data data in the following format:
+                list(  list( question_title, question_link, question_id )  )
+        """
+        try:
+            resp = requests.get(
+                f"{self.search_content_url}/2.2/questions/{self.batch_ques_id[:-1]}/answers?order=desc&sort=votes&site=stackoverflow&filter=!--1nZwsgqvRX"
+            )
+        except:
+            SearchError("Search Failed", "Try connecting to the internet")
+            sys.exit()
+        json_ans_data = resp.json()
+        for item in json_ans_data["items"]:
+            self.answer_data[item['question_id']] = item['body_markdown']
+
+    def return_formatted_ans(self, id):
+        # This function uses pygments lexers ad formatters to format the content in the preview screen
+        body_markdown = self.answer_data[int(id)]
+        if(body_markdown):
+            body_markdown = str(body_markdown)
+            body_markdown = body_markdown.replace("&amp;", "&")
+            body_markdown = body_markdown.replace("&lt;", "<")
+            body_markdown = body_markdown.replace("&gt;", ">")
+            body_markdown = body_markdown.replace("&quot;", "\"")
+            body_markdown = body_markdown.replace("&apos;", "\'")
+            body_markdown = body_markdown.replace("&#39;", "\'")
+            lexer = MarkdownLexer()
+            formatter = Terminal256Formatter(bg="light")
+            highlighted = highlight(body_markdown, lexer, formatter)
+        else:
+            highlighted = "Answer not viewable. Press enter to open in a browser"
+        return highlighted
+
+    def navigate_questions_panel(self):
+        # Code for navigating through the question panel
+        console.rule('[bold blue] Relevant Questions', style="bold red")
+        console.print("[yellow] Use arrow keys to navigate. 'q' or 'Esc' to quit. 'Enter' to open in a browser")
+        console.print()
+        options = ["|".join(map(str, question)) for question in self.questions_data]
+        question_menu = TerminalMenu(options, preview_command=self.return_formatted_ans)
+        quitting = False
+        while not(quitting):
+            options_index = question_menu.show()
+            try:
+                options_choice = options[options_index]
+            except:
+                return
+            else:
+                question_link = self.questions_data[options_index][2]
+                webbrowser.open(question_link)
 
 class Utility():
     def __init__(self):
@@ -52,12 +139,12 @@ class Utility():
         :return: Json response from the api call.
         :rtype: Json format data
         """
-        print("\U0001F50E Searching for the answer")
-        try:
-            resp = requests.get(self.__get_search_url(que, tag))
-        except:
-            SearchError("\U0001F613 Search Failed", "\U0001F4BB Try connecting to the internet")
-            sys.exit()
+        with console.status("Searching..."):
+            try:
+                resp = requests.get(self.__get_search_url(que, tag))
+            except:
+                SearchError("\U0001F613 Search Failed", "\U0001F4BB Try connecting to the internet")
+                sys.exit()
         return resp.json()
 
     def get_que(self, json_data):
@@ -73,109 +160,10 @@ class Utility():
         return que_id
 
     def get_ans(self, questions_list):
-        """
-        This function prints the answer to the queries
-        (question and tags) provided by the user. It does so
-        in the following manner :
-        1) Gets the details of all the relevant question and stores their title, link and id in "question_data" list.
-        2) I have introduced the concept of active question, i.e. , the question whose answer is currently being displayed.
-        3) The index of the active question in "question_data" array is stored in "question_posx"
-        2) By Default, shows the answer to the first question. Creates an breakable infinite loop asking the user answer to which question he wants to see.
-        4) The value of "question_posx" changes according to user input, displaying answer to different questions in "questions_data" list.
-        3) The answers to the questions requested by the user are stored in cache for faster access time during subsequent calls.
-        """
-        # Create batch request to get details of all the questions
-        batch_ques_id = ""
-        for question_id in questions_list:
-            batch_ques_id += str(question_id) + ";"
-        try:
-            resp = requests.get(
-                f"{self.search_content_url}/2.2/questions/{batch_ques_id[:-1]}?order=desc&sort=votes&site=stackoverflow&filter=!--1nZwsgqvRX"
-            )
-        except:
-            SearchError("Search Failed", "Try connecting to the internet")
-            sys.exit()
-        json_ques_data = resp.json()
-        """
-        Store the received questions data into the following data format:
-        list(  list( question_title, question_link, question_id )  )
-        """
-        questions_data = [[item['title'], item['link'], item['question_id']] for item in json_ques_data["items"] ]
-        # Clear terminal
-        os.system('cls' if os.name == 'nt' else 'clear')
-
-        # cache array to store the requested answers. Format of storage { question_id:[answer_body, answer_link] }
-        downloaded_questions_cache = defaultdict(lambda: False)
-
-        # Stores the currently showing question index in questions_data
-        question_posx = 0
-
-        while True:
-            os.system('cls' if os.name == 'nt' else 'clear')
-            # Printing all the questions. The active question is printed GREEN.
-            console.rule('[bold blue] Relevant Questions', style="bold red")
-            for idx, question_data in enumerate(questions_data):
-                if question_posx == idx:
-                    console.print("[green]{}. {}  |  {}".format(idx+1, question_data[0], question_data[1]))
-                else:
-                    console.print("{}. {}  |  {}".format(idx+1, question_data[0], question_data[1]))
-            console.rule("[bold blue] Answer of question {}".format(question_posx+1), style="bold red")
-
-            # Gets the question_id of active question
-            current_question_id = questions_data[question_posx][2]
-
-            # Searches for the id in cache. If present then prints it
-            if(downloaded_questions_cache[current_question_id]):
-                output_content = downloaded_questions_cache[current_question_id]
-                for output_index, output_text in enumerate(output_content):
-                    """
-                    Loop through the output_text and print the element
-                    if it is the last one, the text[0] is printed
-                    along with text[-1]
-
-                    if text is markdown , render the markdown
-                    """
-                    if output_index == len(output_content) - 1:
-                        console.print("Link to the answer: " + output_text)
-                        break
-
-                    if output_index == len(output_content) - 2:
-                        MarkdownRenderer(output_text)
-                        continue
-
-                    console.print(output_text)
-            # If the cache has no entry for the said question id, then downloads the answer
-            # and makes an for it entry in the cache array in the said format and restarts the loop.
-            else:
-                try:
-                    resp = requests.get(
-                        f"{self.search_content_url}/2.2/questions/{current_question_id}/answers?order=desc&sort=votes&site=stackoverflow&filter=!--1nZwsgqvRX"
-                    )
-                except:
-                    SearchError("Search Failed", "Try connecting to the internet")
-                    sys.exit()
-                json_ans_data = resp.json()
-                print(json_ans_data["items"])
-                most_upvoted = json_ans_data["items"][0]
-                downloaded_questions_cache[current_question_id] = [most_upvoted["body_markdown"], most_upvoted['link']]
-                del most_upvoted
-                continue
-
-            console.rule("[bold blue]", style="bold red", align="right")
-            # Asks the user for next question number. Makes it the active question and the loop restarts
-            while True:
-                try:
-                    posx = int(input("Enter the question number you want to view (Press 0 to quit): ")) - 1
-                except ValueError:
-                    SearchError("You didn't enter a question number", "Enter a question number from the relevant questions list")
-                if (posx == -1):
-                    return
-                elif (0<=posx<len(questions_data)):
-                    question_posx = posx
-                    break
-                else:
-                    console.print("Please enter a valid question number")
-                    continue
+        stackoverflow_panel = Questions_Panel_Stackoverflow()
+        stackoverflow_panel.populate_question_data(questions_list)
+        stackoverflow_panel.populate_answer_data()
+        stackoverflow_panel.navigate_questions_panel()
 
     # Get an access token and extract to a JSON file "access_token.json"
     @classmethod

--- a/src/arguments/utility.py
+++ b/src/arguments/utility.py
@@ -2,7 +2,6 @@ from termcolor import colored
 import requests
 from rich.console import Console
 from rich.markdown import Markdown
-from rich.style import Style
 import sys as sys
 
 # Required for Questions Panel

--- a/src/arguments/utility.py
+++ b/src/arguments/utility.py
@@ -59,7 +59,7 @@ class QuestionsPanel_stackoverflow():
                 SearchError("Search Failed", "Try connecting to the internet")
                 sys.exit()
         json_ques_data = resp.json()
-        self.questions_data = [[item['title'], item['question_id'], item['link']] for item in json_ques_data["items"]]
+        self.questions_data = [[item['title'].replace('|',''), item['question_id'], item['link']] for item in json_ques_data["items"]]
 
     def populate_answer_data(self, questions_list):
         """

--- a/src/arguments/utility.py
+++ b/src/arguments/utility.py
@@ -35,7 +35,7 @@ from webdriver_manager.microsoft import EdgeChromiumDriverManager
 
 console = Console()
 
-class Questions_Panel_Stackoverflow():
+class Questions_Panel_stackoverflow():
     def __init__(self):
         self.questions_data = []                        # list(  list( question_title, question_link, question_id )...  )
         self.answer_data = defaultdict(lambda: False)   # dict( question_id:list( body, link )) corresponding to self.questions_data
@@ -61,7 +61,6 @@ class Questions_Panel_Stackoverflow():
             sys.exit()
         json_ques_data = resp.json()
         self.questions_data = [[item['title'], item['question_id'], item['link']] for item in json_ques_data["items"]]
-        return
 
     def populate_answer_data(self):
         """ Function to populate answer data property
@@ -110,7 +109,7 @@ class Questions_Panel_Stackoverflow():
             options_index = question_menu.show()
             try:
                 options_choice = options[options_index]
-            except:
+            except Exception:
                 return
             else:
                 question_link = self.questions_data[options_index][2]
@@ -160,7 +159,7 @@ class Utility():
         return que_id
 
     def get_ans(self, questions_list):
-        stackoverflow_panel = Questions_Panel_Stackoverflow()
+        stackoverflow_panel = Questions_Panel_stackoverflow()
         stackoverflow_panel.populate_question_data(questions_list)
         stackoverflow_panel.populate_answer_data()
         stackoverflow_panel.navigate_questions_panel()

--- a/src/arguments/utility.py
+++ b/src/arguments/utility.py
@@ -1,6 +1,8 @@
 from termcolor import colored
 import requests
 from rich.console import Console
+from rich.markdown import Markdown
+from rich.style import Style
 import sys as sys
 
 # Required for Questions Panel
@@ -9,9 +11,6 @@ import time
 from collections import defaultdict
 from simple_term_menu import TerminalMenu
 import webbrowser
-from pygments import highlight
-from pygments.lexers.markup import MarkdownLexer
-from pygments.formatters import TerminalFormatter
 
 from .error import SearchError
 from .save import SaveSearchResults
@@ -88,16 +87,19 @@ class QuestionsPanelStackoverflow():
     def return_formatted_ans(self, ques_id):
         # This function uses pygments lexers ad formatters to format the content in the preview screen
         body_markdown = self.answer_data[int(ques_id)]
-        if(body_markdown):
-            body_markdown = str(body_markdown)
-            xml_markup_replacement = [("&amp;", "&"), ("&lt;", "<"), ("&gt;", ">"), ("&quot;", "\""), ("&apos;", "\'"), ("&#39;", "\'")]
-            for convert_from, convert_to in xml_markup_replacement:
-                body_markdown = body_markdown.replace(convert_from, convert_to)
-            lexer = MarkdownLexer()
-            formatter = TerminalFormatter()
-            highlighted = highlight(body_markdown, lexer, formatter)
-        else:
-            highlighted = "Answer not viewable. Press enter to open in a browser"
+        body_markdown = str(body_markdown)
+        xml_markup_replacement = [("&amp;", "&"), ("&lt;", "<"), ("&gt;", ">"), ("&quot;", "\""), ("&apos;", "\'"), ("&#39;", "\'")]
+        for convert_from, convert_to in xml_markup_replacement:
+            body_markdown = body_markdown.replace(convert_from, convert_to)
+        width = os.get_terminal_size().columns
+        console = Console(width=width-4)
+        markdown = Markdown(body_markdown, hyperlinks=False)
+        with console.capture() as capture:
+            console.print(markdown)
+        highlighted = capture.get()
+        box_replacement = [("─", "-"), ("═","="), ("║","|"), ("│", "|"), ('┌', '+'), ("└", "+"), ("┐", "+"), ("┘", "+"), ("╔", "+"), ("╚", "+"), ("╗","+"), ("╝", "+"), ("•","*")]
+        for convert_from, convert_to in box_replacement:
+            highlighted = highlighted.replace(convert_from, convert_to)
         return highlighted
 
     def navigate_questions_panel(self):

--- a/src/arguments/utility.py
+++ b/src/arguments/utility.py
@@ -164,7 +164,10 @@ class Utility():
             console.rule("[bold blue]", style="bold red", align="right")
             # Asks the user for next question number. Makes it the active question and the loop restarts
             while True:
-                posx = int(input("Enter the question number you want to view (Press 0 to quit): ")) - 1
+                try:
+                    posx = int(input("Enter the question number you want to view (Press 0 to quit): ")) - 1
+                except ValueError:
+                    SearchError("You didn't enter a question number", "Enter a question number from the relevant questions list")
                 if (posx == -1):
                     return
                 elif (0<=posx<len(questions_data)):

--- a/src/arguments/utility.py
+++ b/src/arguments/utility.py
@@ -11,7 +11,6 @@ from simple_term_menu import TerminalMenu
 import webbrowser
 from pygments import highlight
 from pygments.lexers.markup import MarkdownLexer
-from pygments.lexers.html import HtmlLexer
 from pygments.formatters import TerminalFormatter
 
 from .error import SearchError


### PR DESCRIPTION
## Related Issue
 - No navigation with arrow keys in StackOverflow question panel
 - Can't exit panel with 'Esc' or 'Q' key
 - Value Error in input

Closes: #87 #41 


## Describe the changes you've made
Created a different class for displaying and navigating through the StackOverflow question panel. Users can now navigate through the questions with arrow keys, exit with the 'q' key or 'Esc' key, press 'Enter' to open the question in a browser. The question panel also has Vim-style searching capability with the '/' key. The CLI is very smooth now, although the downside is it takes a bit more time to search as it now downloads answers to all the questions beforehand.

There is a small issue - Sometimes, long markdown texts run off the preview panel. That may cause some problems when the terminal is not used on the full screen. I need some help in fixing that. 

## Checklist:

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.

## Screenshots

|        Original         |          Updated           |
| :---------------------: | :------------------------: |
| **![before](https://user-images.githubusercontent.com/26577306/115413424-c8636400-a212-11eb-8afa-f7c50e4ce105.gif)** | <b>![after](https://user-images.githubusercontent.com/26577306/115413466-d31df900-a212-11eb-8258-36a731cc7f0a.gif)</b> |