### PR TITLE
Adding support for headers for api calls

### DIFF
--- a/src/arguments/api_test.py
+++ b/src/arguments/api_test.py
@@ -11,18 +11,13 @@ class ApiTesting():
         request_headers = cls.default_headers
         input_url = input('Enter URL: ')
         input_headers = input('Enter Headers: ')
-        
         if input_url != '':
             request_url = input_url
-
         if input_headers != '':
             try:
                 request_headers = json.loads(input_headers)
-            # If Exception Occurs while Parsing Headers Printing info    
             except Exception:
                 print("Failed to parse Input Headers")
-
-
         # Check whether the request_url has an endpoint or not
         has_endpoint = cls.__check_endpoint(request_url)
 

--- a/src/arguments/api_test.py
+++ b/src/arguments/api_test.py
@@ -19,7 +19,7 @@ class ApiTesting():
             try:
                 request_headers = json.loads(input_headers)
             # If Exception Occurs while Parsing Headers Printing info    
-            except Exception as ex:
+            except Exception:
                 print("Failed to parse Input Headers")
 
 

--- a/src/arguments/api_test.py
+++ b/src/arguments/api_test.py
@@ -3,14 +3,25 @@ from pygments import highlight, lexers, formatters
 
 class ApiTesting():
     default_url = "https://127.0.0.1:8000"
-
+    default_headers = {}
     # Make GET request
     @classmethod
     def get_request(cls):
         request_url = cls.default_url
+        request_headers = cls.default_headers
         input_url = input('Enter URL: ')
+        input_headers = input('Enter Headers: ')
+        
         if input_url != '':
             request_url = input_url
+
+        if input_headers != '':
+            try:
+                request_headers = json.loads(input_headers)
+            # If Exception Occurs while Parsing Headers Printing info    
+            except Exception as ex:
+                print("Failed to parse Input Headers")
+
 
         # Check whether the request_url has an endpoint or not
         has_endpoint = cls.__check_endpoint(request_url)
@@ -33,7 +44,7 @@ class ApiTesting():
 
         # Make GET request and store the response in response_data.json
         try:
-            response = requests.get(request_url)
+            response = requests.get(request_url, headers=request_headers)
             print(f"Reponse Status Code: {response.status_code}")
             response_data = json.loads(response.content)
             parsed_json = json.dumps(response_data, indent=4)


### PR DESCRIPTION
## Description

Custom Headers are necessary ingredients for making an authorized request to some end-points, hence support for passing in custom headers can improve the applicability of the service.

In this PR I have added support for adding headers while making GET API calls using the client. The new feature prompts users to input custom headers in their API calls. The user can choose to skip it by pressing enter, otherwise, they can provide a valid Header dictionary which will be parsed and added as headers in the API Call. If any exception occurs while parsing currently printing info [Parse error occured] and continuing the API request.


Inputs:
<img width="655" alt="Screenshot 2021-04-20 at 8 53 56 PM" src="https://user-images.githubusercontent.com/25389167/115423452-76730c00-a21b-11eb-9771-adb28c4f8eed.png">

Webhook Output:
<img width="1225" alt="Screenshot 2021-04-20 at 8 54 11 PM" src="https://user-images.githubusercontent.com/25389167/115423581-9276ad80-a21b-11eb-9640-9606a01212c8.png">


## Checklist:

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.

## Screenshots

|        Original         |          Updated           |
| :---------------------: | :------------------------: |
| **original screenshot** | <b>updated screenshot </b> |
