### PR TITLE
Add playbook feature

### DIFF
--- a/main.py
+++ b/main.py
@@ -50,6 +50,11 @@ parser.add_argument("-GET",
                     help="Make a GET request to an API",
                     action='store_true')
 
+parser.add_argument("-p",
+                    "--playbook",
+                    help="View and organise the playbook",
+                    action='store_true')
+
 ARGV = parser.parse_args()
 
 search_flag = Search(ARGV)

--- a/src/arguments/search.py
+++ b/src/arguments/search.py
@@ -36,6 +36,8 @@ class Search():
             self.search_for_results()
         elif self.arguments.file:
             self.search_for_results(True)
+        elif self.arguments.playbook:
+            self.utility_object.display_playbook()
         elif self.arguments.new:
             url = "https://stackoverflow.com/questions/ask"
             if type(self.arguments.new) == str:

--- a/src/arguments/search.py
+++ b/src/arguments/search.py
@@ -6,6 +6,7 @@ import sys as sys
 
 from .error import SearchError
 from .utility import Utility
+from .utility import Playbook
 from .save import SaveSearchResults
 from .update import UpdateApplication
 from .api_test import ApiTesting
@@ -30,6 +31,7 @@ class Search():
         self.arguments = arguments
         self.utility_object = Utility()
         self.api_test_object = ApiTesting()
+        self.playbook_object = Playbook()
 
     def search_args(self):
         if self.arguments.search:
@@ -37,7 +39,7 @@ class Search():
         elif self.arguments.file:
             self.search_for_results(True)
         elif self.arguments.playbook:
-            self.utility_object.display_playbook()
+            self.playbook_object.display_panel()
         elif self.arguments.new:
             url = "https://stackoverflow.com/questions/ask"
             if type(self.arguments.new) == str:

--- a/src/arguments/utility.py
+++ b/src/arguments/utility.py
@@ -129,7 +129,7 @@ class Playbook():
         os.system('cls' if os.name == 'nt' else 'clear')
         self = Playbook()
         self.display_panel()
-                    
+
     def display_panel(self):
         playbook_data = self.playbook_content
         if(len(playbook_data['items_stackoverflow']) == 0):

--- a/src/arguments/utility.py
+++ b/src/arguments/utility.py
@@ -228,10 +228,7 @@ class QuestionsPanelStackoverflow():
             try:
                 question_link = self.questions_data[options_index][2]
             except Exception:
-                if(playbook):
-                    sys.exit()
-                else:
-                    return
+                return sys.exit() if playbook else None
             else:
                 if(question_menu.chosen_accept_key == 'enter'):
                     webbrowser.open(question_link)

--- a/src/arguments/utility.py
+++ b/src/arguments/utility.py
@@ -37,17 +37,15 @@ console = Console()
 class Playbook():
     def __init__(self):
         self.linux_path = "/home/{}/Documents/dynamic".format(os.getenv('USER'))
-        self.windows_path = repr("c:\\Users\\{}\\My Documents".format(os.getenv('USERNAME')))
-        self.unix_path = "." # Add mac support here
+        self.mac_path = "/Users/{}/Documents/dynamic".format(os.getenv('USER'))
         self.file_name = 'dynamic_playbook.json'
-        self.log = open('logplaybook.txt', 'w')
 
     @property
     def playbook_path(self):
         if(sys.platform=='linux'):
             return os.path.join(self.linux_path, self.file_name)
-        elif(sys.platform=='win32'):
-            return os.path.join(self.windows_path, self.file_name)
+        if(sys.platform=='darwin'):
+            return os.path.join(self.mac_path, self.file_name)
 
     @property
     def playbook_template(self):
@@ -123,7 +121,6 @@ class Playbook():
 
     def delete_from_playbook(self, stackoverflow_object, question_id):
         content = self.playbook_content
-        self.log.write(str(len(content["items_stackoverflow"])))
         for i in range(len(content["items_stackoverflow"])):
             if content["items_stackoverflow"][i]["question_id"] == question_id:
                 del content["items_stackoverflow"][i]
@@ -152,7 +149,6 @@ class QuestionsPanelStackoverflow():
         self.heading_color = "bold blue"
         self.utility = Utility()
         self.playbook = Playbook()
-        self.log = open('logs.txt', 'w')
 
     def populate_question_data(self, questions_list):
         """

--- a/src/arguments/utility.py
+++ b/src/arguments/utility.py
@@ -7,10 +7,10 @@ import sys as sys
 # Required for Questions Panel
 import os
 import time
+import locale
 from collections import defaultdict
 from simple_term_menu import TerminalMenu
 import webbrowser
-import time
 
 from .error import SearchError
 from .save import SaveSearchResults
@@ -106,7 +106,7 @@ class Playbook():
         """
         if self.is_question_in_playbook(question_id):
             SearchError("Question is already in the playbook", "No need to add")
-            sys.exit()
+            return
         for question in stackoverflow_object.questions_data:
             if(int(question[1])==int(question_id)):
                 content = self.playbook_content
@@ -209,9 +209,10 @@ class QuestionsPanelStackoverflow():
         with console.capture() as capture:
             console.print(markdown)
         highlighted = capture.get()
-        box_replacement = [("─", "-"), ("═","="), ("║","|"), ("│", "|"), ('┌', '+'), ("└", "+"), ("┐", "+"), ("┘", "+"), ("╔", "+"), ("╚", "+"), ("╗","+"), ("╝", "+"), ("•","*")]
-        for convert_from, convert_to in box_replacement:
-            highlighted = highlighted.replace(convert_from, convert_to)
+        if locale.getlocale()[1] !='UTF-8':
+            box_replacement = [("─", "-"), ("═","="), ("║","|"), ("│", "|"), ('┌', '+'), ("└", "+"), ("┐", "+"), ("┘", "+"), ("╔", "+"), ("╚", "+"), ("╗","+"), ("╝", "+"), ("•","*")]
+            for convert_from, convert_to in box_replacement:
+                highlighted = highlighted.replace(convert_from, convert_to)
         return highlighted
 
     def navigate_questions_panel(self, playbook=False):

--- a/src/arguments/utility.py
+++ b/src/arguments/utility.py
@@ -39,13 +39,17 @@ class Playbook():
         self.linux_path = "/home/{}/Documents/dynamic".format(os.getenv('USER'))
         self.mac_path = "/Users/{}/Documents/dynamic".format(os.getenv('USER'))
         self.file_name = 'dynamic_playbook.json'
+        self.key = 'DYNAMIC'
 
     @property
     def playbook_path(self):
-        if(sys.platform=='linux'):
-            return os.path.join(self.linux_path, self.file_name)
-        if(sys.platform=='darwin'):
-            return os.path.join(self.mac_path, self.file_name)
+        # Create an environment variable 'DYNAMIC' containing the path of dynamic_playbook.json and returns it
+        if not os.getenv(self.key):
+            if(sys.platform=='linux'):
+                os.environ[self.key] = os.path.join(self.linux_path, self.file_name)
+            elif(sys.platform=='darwin'):
+                os.environ[self.key] = os.path.join(self.mac_path, self.file_name)
+        return os.getenv(self.key)
 
     @property
     def playbook_template(self):
@@ -66,23 +70,6 @@ class Playbook():
 
     @playbook_content.setter
     def playbook_content(self, value):
-        """
-        Saves playbook in the following format
-        {
-            time_of_update: unix,
-            items_stackoverflow:
-            [
-                {
-                    time: unix timestamp
-                    question_id: 123456,
-                    question_title: 'question_title',
-                    question_link:  'link',
-                    answer_body: 'body of the answer'
-                },
-                ...
-            ]
-        }
-        """
         if isinstance(value, dict):
             with open(self.playbook_path, 'w') as playbook:
                 json.dump(value, playbook, ensure_ascii=False)
@@ -100,9 +87,23 @@ class Playbook():
         """
         Receives a QuestionsPanelStackoverflow object and
         saves data of a particular question into playbook
+        Saves playbook in the following format
+        {
+            time_of_update: unix,
+            items_stackoverflow:
+            [
+                {
+                    time: unix timestamp
+                    question_id: 123456,
+                    question_title: 'question_title',
+                    question_link:  'link',
+                    answer_body: 'body of the answer'
+                },
+                ...
+            ]
         """
         if self.is_question_in_playbook(question_id):
-            SearchError("Question is already in the playbook", "No need to add")
+            console.print("[red] Question is already in the playbook, No need to add")
             return
         for question in stackoverflow_object.questions_data:
             if(int(question[1])==int(question_id)):

--- a/src/arguments/utility.py
+++ b/src/arguments/utility.py
@@ -68,7 +68,7 @@ class Playbook():
     def playbook_content(self, value):
         """
         Saves playbook in the following format
-        {   
+        {
             time_of_update: unix,
             items_stackoverflow:
             [
@@ -83,10 +83,9 @@ class Playbook():
             ]
         }
         """
-        if type(value) == dict:
+        if isinstance(value, dict):
             with open(self.playbook_path, 'w') as playbook:
                 json.dump(value, playbook, ensure_ascii=False)
-            pass
         else:
             raise ValueError("value should be of type dict")
 
@@ -96,10 +95,10 @@ class Playbook():
             if int(entry['question_id']) == int(question_id):
                 return True
         return False
-    
+
     def add_to_playbook(self, stackoverflow_object, question_id):
         """
-        Receives a QuestionsPanelStackoverflow object and 
+        Receives a QuestionsPanelStackoverflow object and
         saves data of a particular question into playbook
         """
         if self.is_question_in_playbook(question_id):
@@ -136,11 +135,12 @@ class Playbook():
         if(len(playbook_data['items_stackoverflow']) == 0):
             SearchError("You have no entries in the playbook", "Browse and save entries in playbook with 'p' key")
             sys.exit()
+        # Creates QuestionPanelStackoverflow object, populates its question_data and answer_data and displays it
         question_panel = QuestionsPanelStackoverflow()
         for item in playbook_data['items_stackoverflow']:
             question_panel.questions_data.append( [item['question_title'], item['question_id'], item['question_link']] )
             question_panel.answer_data[item['question_id']] = item['answer_body']
-        question_panel.display_panel(playbook=True)
+        question_panel.display_panel([], playbook=True)
 
 class QuestionsPanelStackoverflow():
     def __init__(self):
@@ -235,8 +235,8 @@ class QuestionsPanelStackoverflow():
                 elif(question_menu.chosen_accept_key == 'd' and playbook):
                     self.playbook.delete_from_playbook(self, self.questions_data[options_index][1])
 
-    def display_panel(self, questions_list=[], playbook=False):
-        if len(questions_list) != 0:
+    def display_panel(self, questions_list, playbook=False):
+        if not playbook:
             self.populate_question_data(questions_list)
             self.populate_answer_data(questions_list)
         self.navigate_questions_panel(playbook=playbook)
@@ -308,10 +308,6 @@ class Utility():
         stackoverflow_panel = QuestionsPanelStackoverflow()
         stackoverflow_panel.display_panel(questions_list)
         # Support for reddit searching can also be implemented from here
-
-    def display_playbook(self):
-        playbook = Playbook()
-        playbook.display_panel()
 
     # Get an access token and extract to a JSON file "access_token.json"
     @classmethod

--- a/src/arguments/utility.py
+++ b/src/arguments/utility.py
@@ -118,6 +118,7 @@ class Playbook():
                     'answer_body': stackoverflow_object.answer_data[int(question_id)]
                 })
                 self.playbook_content = content
+                console.print("[green] Question added to the playbook")
 
     def delete_from_playbook(self, stackoverflow_object, question_id):
         content = self.playbook_content


### PR DESCRIPTION
## Related Issue
- Users can save questions in the playbook while searching from StackOverflow
- Saved questions will be accessible with the `-p` flag


Closes: #85 


## Describe the changes you've made
<!-- 
A clear and concise description of what you have done to close your assigned issue successfully. Any new files? Or anything you feel to let us know!
-->
Users can save questions in the playbook with the `p` key. The saved answers will be stored locally in the Documents folder for Mac and Linux systems inside the `Dynamic` folder in a file named `dynamic_playbook.json`. **Testing for Mac yet needs to be done.** I don't have a Mac currently to test this on.

The saved answers can be browsed similarly to the StackOverflow question panel with the `dynamic -p` command and deleted with the `d` key.

The code uses the previously implemented QuestionsPanelStackoverflow panel to print the menu, therefore the style of navigation is similar. 

## Checklist:

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.

## Screenshots

|        Original         |     
| :---------------------: |
| **![background](https://user-images.githubusercontent.com/26577306/116260796-a595fa00-a794-11eb-8aa5-3a4ef7d65862.gif)** |

## Updated 
https://imgur.com/FxSlezt.mp4

## Warning
Since the new code is accessing now user file system we need to provide superuser permission while installing. This can be done with the command below
```
sudo python3 -m pip install -e .
```
If installed in the previous way, it will give permission denied error while installation.