### PR TITLE
StackOverflow Query does not contain tags even if entered

### DIFF
--- a/dynamic/search.py
+++ b/dynamic/search.py
@@ -68,9 +68,7 @@ class Search:
             # KeyBoard Interrupts or EOErrors
             try:
                 prompt = Prompt(str(each_query)).prompt()
-                if each_query == "Tags":
-                    continue
-                if prompt.strip() == "":
+                if not each_query == "Tags" and prompt.strip() == "":
                     SearchError(
                         "\U0001F613 Input data empty", "\U0001F504 Please try again "
                     )


### PR DESCRIPTION
## Related Issue
StackOverflow Query does not contain tags even if entered 

Closes: #148 


## Describe the changes you've made
Removed continue if Query is Tags. 


## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.

## Screenshots

|        Original         |          Updated           |
| :---------------------: | :------------------------: |
|<b>![Screen Shot 2022-01-10 at 9 20 55 AM](https://user-images.githubusercontent.com/33164379/148716544-f2d1af15-6974-473e-aa8d-4641e43740db.png)</b>|<b>![Screen Shot 2022-01-10 at 9 20 01 AM](https://user-images.githubusercontent.com/33164379/148716555-18bf0693-c058-4d66-94e3-32b4e15ff383.png)</b>|
