### PR TITLE
FIXED : $ signs are getting copied while copying commands from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,31 +160,31 @@ To deactivate the `dynamic-cli` `virtualenv`, run:
 **1.** Installing pip
 
 ```shell
-$ sudo apt-get install python3-pip
+sudo apt-get install python3-pip
 ```
 
 **2.** Clone this repository to your local drive
 
 ```shell
-$ git clone https://github.com/IndianOpenSourceFoundation/dynamic-cli.git
+git clone https://github.com/IndianOpenSourceFoundation/dynamic-cli.git
 ```
 
 **3.** Go to dynamic directory
 
 ```shell
-$ cd dynamic-cli/
+cd dynamic-cli/
 ```
 
 **4.** Install dependencies
 
 ```shell
-$ pip3 install -r requirements.txt
+pip3 install -r requirements.txt
 ```
 
 **5.** Install with pip
 
 ```shell
-$ pip3 install -e .
+pip3 install -e .
 ```
 
 **If you face some issue running dynamic on mac, follow the below instructions**

--- a/README.md
+++ b/README.md
@@ -70,27 +70,27 @@ Options: <br>
 
 `dynamic-cli` is hosted on [PyPI](https://pypi.python.org/pypi/dynamic-cli).  The following command will install `Dynamic-cli`:
 
-    $ pip3 install dynamic-cli
+    pip3 install dynamic-cli
 
 You can also install the latest `dynamic-cli` from GitHub source which can contain changes not yet pushed to PyPI:
 
-    $ pip3 install git+https://github.com/IndianOpenSourceFoundation/dynamic-cli.git
+    pip3 install git+https://github.com/IndianOpenSourceFoundation/dynamic-cli.git
 
 If you are not installing in a `virtualenv`, you might need to run with `sudo`:
 
-    $ sudo pip3 install dynamic-cli
+    sudo pip3 install dynamic-cli
 
 #### `pip3`
 
 Depending on your setup, you might also want to run `pip3` with the [`-H flag`](http://stackoverflow.com/a/28619739):
 
-    $ sudo -H pip3 install dynamic-cli
+    sudo -H pip3 install dynamic-cli
 
 For most linux users, `pip3` can be installed on your system using the `python3-pip` package.
 
 For example, Ubuntu users can run:
 
-    $ sudo apt-get install python3-pip
+    sudo apt-get install python3-pip
 
 
 ### Virtual Environment Installation
@@ -101,36 +101,36 @@ If you are a Windows user or if you would like more details on `virtualenv`, che
 
 Install `virtualenv` and `virtualenvwrapper`:
 
-    $ pip3 install virtualenv
-    $ pip3 install virtualenvwrapper
-    $ export WORKON_HOME=~/.virtualenvs
-    $ source /usr/local/bin/virtualenvwrapper.sh
+    pip3 install virtualenv
+    pip3 install virtualenvwrapper
+    export WORKON_HOME=~/.virtualenvs
+    source /usr/local/bin/virtualenvwrapper.sh
 
 Create a `dynamic-cli` `virtualenv` and install `dynamic-cli`:
 
-    $ mkvirtualenv dynamic-cli
-    $ pip3 install dynamic-cli
+    mkvirtualenv dynamic-cli
+    pip3 install dynamic-cli
 
 If the `pip` install does not work, you might be running Python 2 by default.  Check what version of Python you are running:
 
-    $ python --version
+    python --version
 
 If the call above results in Python 2, find the path for Python 3:
 
-    $ which python3  # Python 3 path for mkvirtualenv's --python option
+    which python3  # Python 3 path for mkvirtualenv's --python option
 
 Install Python 3 if needed.  Set the Python version when calling `mkvirtualenv`:
 
-    $ mkvirtualenv --python [Python 3 path from above] dynamic-cli
-    $ pip3 install dynamic-cli
+    mkvirtualenv --python [Python 3 path from above] dynamic-cli
+    pip3 install dynamic-cli
 
 If you want to activate the `dynamic-cli` `virtualenv` again later, run:
 
-    $ workon dynamic-cli
+    workon dynamic-cli
 
 To deactivate the `dynamic-cli` `virtualenv`, run:
 
-    $ deactivate
+    deactivate
 
 
 ### Supported Python Versions
@@ -169,15 +169,16 @@ $ sudo apt-get install python3-pip
 $ git clone https://github.com/IndianOpenSourceFoundation/dynamic-cli.git
 ```
 
-**3.** Install dependencies
-
-```shell
-$ pip3 install -r requirements.txt
-```
-**4.** Go to dynamic directory
+**3.** Go to dynamic directory
 
 ```shell
 $ cd dynamic-cli/
+```
+
+**4.** Install dependencies
+
+```shell
+$ pip3 install -r requirements.txt
 ```
 
 **5.** Install with pip


### PR DESCRIPTION
Related Issue #169 
- $ signs are getting copied while copying commands from readme
- Interchanged the 3rd and the 4th section of the [Developer Installation Section](https://github.com/IndianOpenSourceFoundation/dynamic-cli#developer-installation).


Closes: #169 


## Describe the changes you've made
Removed $ sign from all the code snippets in the documentation, avoiding the annoying error `$: command not found error` everytime a user starts out with the initial setup.

Also, following on the suggestion of @shivankar-p, interchanged the 3rd and the 4th section of the [Developer Installation
Section](https://github.com/IndianOpenSourceFoundation/dynamic-cli#developer-installation).

## Checklist:

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.

## Screenshots

|        Original         |          Updated           |
| :---------------------: | :------------------------: |
| **![image](https://user-images.githubusercontent.com/64722289/158018608-cda140bf-ae54-41bb-a264-ca0a6cbe1ec4.png)** | <b>![image](https://user-images.githubusercontent.com/64722289/158018598-3e7ecb19-e80a-4dc5-b3ee-42b5edcb50eb.png) </b> |
