### PR TITLE
Used html module to unescape html characters

### DIFF
--- a/dynamic/utility.py
+++ b/dynamic/utility.py
@@ -33,6 +33,9 @@ from webdriver_manager.chrome import ChromeDriverManager
 from webdriver_manager.firefox import GeckoDriverManager
 from webdriver_manager.microsoft import EdgeChromiumDriverManager
 
+# Required for replacing html escape characters with their corresponding ascii characters
+import html
+
 console = Console()
 
 
@@ -183,6 +186,18 @@ class QuestionsPanelStackoverflow:
         self.utility = Utility()
         self.playbook = Playbook()
 
+    def replaceHtmlEscapeCharacters(self, question_title):
+        """
+            Function to replace HTML escape characters in question's title
+                to their corresponding ASCII characters
+            For example, if the title was something like this:
+                '&quot;static const&quot; vs &quot;#define&quot; vs &quot;enum&quot;'
+                the HTML escape characters would be replaced with their corresponding ASCII
+                characters and the resulting string would be:
+                '"static const" vs "#define" vs "enum"'
+        """
+        return html.unescape(question_title)
+
     def populate_question_data(self, questions_list):
         """
         Function to populate question data property
@@ -199,7 +214,7 @@ class QuestionsPanelStackoverflow:
                 sys.exit()
         json_ques_data = resp.json()
         self.questions_data = [
-            [item["title"].replace("|", ""), item["question_id"], item["link"]]
+            [self.replaceHtmlEscapeCharacters(item["title"].replace("|", "")), item["question_id"], item["link"]]
             for item in json_ques_data["items"]
         ]
 

--- a/dynamic/utility.py
+++ b/dynamic/utility.py
@@ -195,7 +195,7 @@ class QuestionsPanelStackoverflow:
         details of questions with id in the list. Stores the returned
         data in the following format:
             list(  list( question_title, question_link, question_id )  )
-        User html.unescape function to convert html character references
+        Uses html.unescape function to convert html character references
         to the corresponding unicode to corresponding unicode characters
         """
         with console.status("Getting the questions..."):

--- a/dynamic/utility.py
+++ b/dynamic/utility.py
@@ -1,5 +1,6 @@
-# Required for replacing html escape characters with their corresponding ascii characters
+""" Required for replacing html escape characters with their corresponding unicode/ascii characters """
 import html
+
 from termcolor import colored
 import requests
 from rich.console import Console
@@ -187,18 +188,6 @@ class QuestionsPanelStackoverflow:
         self.utility = Utility()
         self.playbook = Playbook()
 
-    def unescape_html_characters(self, question_title):
-        """
-            Function to replace HTML escape characters in question's title
-                to their corresponding ASCII characters
-            For example, if the title was something like this:
-                '&quot;static const&quot; vs &quot;#define&quot; vs &quot;enum&quot;'
-                the HTML escape characters would be replaced with their corresponding ASCII
-                characters and the resulting string would be:
-                '"static const" vs "#define" vs "enum"'
-        """
-        return html.unescape(question_title)
-
     def populate_question_data(self, questions_list):
         """
         Function to populate question data property
@@ -206,6 +195,8 @@ class QuestionsPanelStackoverflow:
         details of questions with id in the list. Stores the returned
         data in the following format:
             list(  list( question_title, question_link, question_id )  )
+        User html.unescape function to convert html character references
+        to the corresponding unicode to corresponding unicode characters
         """
         with console.status("Getting the questions..."):
             try:
@@ -215,7 +206,7 @@ class QuestionsPanelStackoverflow:
                 sys.exit()
         json_ques_data = resp.json()
         self.questions_data = [
-            [self.unescape_html_characters(item["title"].replace("|", "")), item["question_id"], item["link"]]
+            [html.unescape(item["title"].replace("|", "")), item["question_id"], item["link"]]
             for item in json_ques_data["items"]
         ]
 

--- a/dynamic/utility.py
+++ b/dynamic/utility.py
@@ -1,3 +1,5 @@
+# Required for replacing html escape characters with their corresponding ascii characters
+import html
 from termcolor import colored
 import requests
 from rich.console import Console
@@ -33,8 +35,7 @@ from webdriver_manager.chrome import ChromeDriverManager
 from webdriver_manager.firefox import GeckoDriverManager
 from webdriver_manager.microsoft import EdgeChromiumDriverManager
 
-# Required for replacing html escape characters with their corresponding ascii characters
-import html
+
 
 console = Console()
 
@@ -186,7 +187,7 @@ class QuestionsPanelStackoverflow:
         self.utility = Utility()
         self.playbook = Playbook()
 
-    def replaceHtmlEscapeCharacters(self, question_title):
+    def unescape_html_characters(self, question_title):
         """
             Function to replace HTML escape characters in question's title
                 to their corresponding ASCII characters
@@ -214,7 +215,7 @@ class QuestionsPanelStackoverflow:
                 sys.exit()
         json_ques_data = resp.json()
         self.questions_data = [
-            [self.replaceHtmlEscapeCharacters(item["title"].replace("|", "")), item["question_id"], item["link"]]
+            [self.unescape_html_characters(item["title"].replace("|", "")), item["question_id"], item["link"]]
             for item in json_ques_data["items"]
         ]
 

--- a/dynamic/utility.py
+++ b/dynamic/utility.py
@@ -1,4 +1,5 @@
-""" Required for replacing html escape characters with their corresponding unicode/ascii characters """
+""" Required for replacing html escape characters with their
+    corresponding unicode/ascii characters """
 import html
 
 from termcolor import colored


### PR DESCRIPTION
## Related Issue
While displaying question titles in the panel, if the question contained and some character like '"' (double quote) it was displayed as its corresponding html escape character which is '\&quot;'  which didn't seem human readable at all if there multiple html escape characters in a title.


Closes: #184


## Describe the changes you've made

I created a function which uses the built in **html** module to unescape those characters from that particular title.



## Checklist:

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.

## Screenshots

### Input string: ' vs " in c


|        Original         |          Updated           |
| :---------------------: | :------------------------: |
| ![image](https://drive.google.com/uc?export=view&id=15Nwp2G73ah8797LLCiZq8kbC7C3TSeF1) | ![image](https://drive.google.com/uc?export=view&id=1T8iCGV84lFRhbB8b8X5rPjNmPyOGiDi_) |
